### PR TITLE
fix: add typescript definitions for simple slider props

### DIFF
--- a/components/SimpleSlider.tsx
+++ b/components/SimpleSlider.tsx
@@ -27,7 +27,26 @@ function SamplePrevArrow(props) {
   );
 }
 
-export default class SimpleSlider extends Component {
+type SimpleSliderProps = { 
+  background1: string,
+  backgroundOverlay1: string,
+  logo1: string,
+  quote1: string,
+  name1: string,
+  cta1: string,
+  background2: string,
+  backgroundOverlay2: string,
+  logo2: string,
+  quote2: string,
+  name2: string,
+  cta2: string,
+};
+export default class SimpleSlider extends Component<SimpleSliderProps> {
+
+  constructor(props) {
+    super(props)
+  }
+
   render() {
     const settings = {
       infinite: true,
@@ -40,69 +59,73 @@ export default class SimpleSlider extends Component {
       prevArrow: <SamplePrevArrow />
     };
 
-    return (
-      <div className="max-w-7xl m-auto shadow-2xl">
-        <Slider {...settings}>
-          <div className="">
-            <div className="relative">
-              <div className="relative lg:flex overflow-hidden rounded-md">
-                <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center">
-                  <img className="absolute h-full w-full object-cover" src="../images/CarTalk-Testimonial-Image.jpg" alt="" />
-                  <div className="absolute inset-0 bg-alkali-600 opacity-75"></div>
-                  <img className="relative" width="275" height="120" src="../images/CarTalk-Repair.png"></img>
-                </div>
-                <div className="relative lg:w-7/12 bg-white">
-                  <svg className="absolute h-full text-white w-24 -ml-12" fill="currentColor" viewBox="0 0 100 100" preserveAspectRatio="none">
-                    <polygon points="50,0 100,0 50,100 0,100" />
-                  </svg>
-                  <div className="relative py-12 lg:py-24 px-8 lg:px-16 text-gray-700 leading-relaxed">
-                    <p className="text-gray-900 font-open font-medium">
-                      "Starting off as a new business we realized the importance of having a sound online presence early on. We are extremely grateful we found Alkali Designs we did. They have provided us the tools we need to adequately serve our customers."</p>
-                    <p className="mt-3 font-open font-bold">
-                      -Cody Lintz, Owner of CarTalk Repair</p>
-                    <p className="mt-6">
-                      <a href="#" className="font-medium font-open duration-500 text-black hover:text-alkali-500">Learn more about CarTalk's project &rarr;</a>
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div className="absolute inset-y-0 left-0 lg:flex lg:items-center">
 
-              </div>
-              <div className="absolute inset-y-0 right-0 lg:flex lg:items-center">
-              </div>
-            </div>
-          </div>
-          <div className="">
-            <div className="relative">
-              <div className="relative lg:flex overflow-hidden rounded-md">
-                <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center">
-                  <img className="absolute h-full w-full object-cover" src="../images/CarTalk-Testimonial-Image.jpg" alt="" />
-                  <div className="absolute inset-0 bg-alkali-600 opacity-75"></div>
-                  <img className="relative" width="275" height="120" src="../images/CarTalk-Repair.png"></img>
-                </div>
-                <div className="relative lg:w-7/12 bg-white">
-                  <svg className="absolute h-full text-white w-24 -ml-12" fill="currentColor" viewBox="0 0 100 100" preserveAspectRatio="none">
-                    <polygon points="50,0 100,0 50,100 0,100" />
-                  </svg>
-                  <div className="relative py-12 lg:py-24 px-8 lg:px-16 text-gray-700 leading-relaxed">
-                    <p text-gray-900 font-open font-medium>
-                      "Starting off as a new business we realized the importance of having a sound online presence early on. We are extremely grateful we found Alkali Designs we did. They have provided us the tools we need to adequately serve our customers."</p>
-                    <p className="mt-3 font-open font-bold">
-                      -Cody Lintz, Owner of CarTalk Repair</p>
-                    <p className="mt-6">
-                      <a href="#" className="font-medium duration-500 text-black hover:text-alkali-500">Learn more about CarTalk's project &rarr;</a>
-                    </p>
+    return (
+      <div className="mx-14">
+        <div className="max-w-7xl m-auto shadow-2xl rounded-md">
+          <Slider {...settings}>
+            <div className="">
+              <div className="relative">
+                <div className="relative lg:flex overflow-hidden rounded-md">
+                  <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center">
+                    <img className="absolute h-full w-full object-cover" src={this.props.background1} alt="" />
+                    <div className={this.props.backgroundOverlay1}></div>
+                    <img className="relative" width="275" height="120" src={this.props.logo1}></img>
+                  </div>
+                  <div className="relative lg:w-7/12 bg-white">
+                    <svg className="absolute h-full text-white w-24 -ml-12" fill="currentColor" viewBox="0 0 100 100" preserveAspectRatio="none">
+                      <polygon points="50,0 100,0 50,100 0,100" />
+                    </svg>
+                    <div className="relative py-12 lg:py-24 px-8 lg:px-16 text-gray-700 leading-relaxed">
+                      <p className="text-gray-900 font-open font-medium">
+                        {this.props.quote1}
+                      </p>
+                      <p className="mt-3 font-open font-bold">
+                        {this.props.name1}</p>
+                      <p className="mt-6">
+                        <a href="#" className="font-medium font-open duration-500 text-black hover:text-alkali-500">{this.props.cta1}</a>
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div className="absolute inset-y-0 left-0 lg:flex lg:items-center">
-              </div>
-              <div className="absolute inset-y-0 right-0 lg:flex lg:items-center">
+                <div className="absolute inset-y-0 left-0 lg:flex lg:items-center">
+                </div>
+                <div className="absolute inset-y-0 right-0 lg:flex lg:items-center">
+                </div>
               </div>
             </div>
-          </div>
-        </Slider>
+            <div className="">
+              <div className="relative">
+                <div className="relative lg:flex overflow-hidden rounded-md">
+                  <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center">
+                    <img className="absolute h-full w-full object-cover" src={this.props.background2} alt="" />
+                    <div className={this.props.backgroundOverlay2}></div>
+                    <img className="relative" width="275" height="120" src={this.props.logo2}></img>
+                  </div>
+                  <div className="relative lg:w-7/12 bg-white">
+                    <svg className="absolute h-full text-white w-24 -ml-12" fill="currentColor" viewBox="0 0 100 100" preserveAspectRatio="none">
+                      <polygon points="50,0 100,0 50,100 0,100" />
+                    </svg>
+                    <div className="relative py-12 lg:py-24 px-8 lg:px-16 text-gray-700 leading-relaxed">
+                      <p className="text-gray-900 font-open font-medium">
+                        {this.props.quote2}
+                      </p>
+                      <p className="mt-3 font-open font-bold">
+                        {this.props.name2}</p>
+                      <p className="mt-6">
+                        <a href="#" className="font-medium font-open duration-500 text-black hover:text-alkali-500">{this.props.cta2}</a>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="absolute inset-y-0 left-0 lg:flex lg:items-center">
+                </div>
+                <div className="absolute inset-y-0 right-0 lg:flex lg:items-center">
+                </div>
+              </div>
+            </div>
+          </Slider>
+        </div>
       </div>
     );
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,7 +50,20 @@ export default function Home() {
       />
       <div className="pt-24 -mt-96">
         <h3 className="text-4xl pt-2 pb-16 font-play font-bold text-center">What Our Clients Say</h3>
-        <SimpleSlider />
+        <SimpleSlider
+          background1={'/images/carro-after.jpg'}
+          backgroundOverlay1={'/images/carro-cover.jpg'}
+          logo1={'/images/alkali-logo-alt.png'}
+          quote1={'Some sample quote here'}
+          name1={'Name here'}
+          cta1={'Take action'}
+          background2={'/images/carro-after.jpg'}
+          backgroundOverlay2={'/images/carro-cover.jpg'}
+          logo2={'/images/alkali-logo-alt.png'}
+          quote2={'Some sample quote here'}
+          name2={'Name here'}
+          cta2={'Take action'}
+        />
       </div>
       <div className="pt-48">
         <h3 id="services" className="text-4xl font-play font-bold text-center">Our Services</h3>


### PR DESCRIPTION
Hey @baudoinalkali - I think I've fixed your problem for ya. I didn't realize when I was looking at this last night that you're using TypeScript. TS requires type definitions for the props on your class based components, which is why it wasn't recognizing the props. 

[Here's a good reference sheet on class components with TypeScript](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/class_components/)

I've added some type definitions (I set them all as strings, assuming you're just passing image URLs and the like), and then tried it out with some of the images you have in the `public` directory. I just chose whatever was close to the top and kind of made sense. I ran `yarn dev` and verified that the values were coming through in the slider on the home page with no errors. I think we're in good shape there. I'll make some inline comments in the code here to demonstrate what I was talking about.