### PR TITLE
move JSX into constants at the top level

### DIFF
--- a/pages/clients/carro.tsx
+++ b/pages/clients/carro.tsx
@@ -20,6 +20,21 @@ import ClientBlocks from '../../content/clientPages/clientBlocks'
 
 
 function Carro2() {
+  const carroImages = ClientBlocks.carro.map(carro =>
+    <AngledImage
+      image={carro.image}
+      layout="left"
+    />
+  )
+
+  const carroText = ClientBlocks.carro.map(carro =>
+    <StandardTextBlock
+      sub={carro.sub}
+      title={carro.title}
+      text={carro.text}
+    />
+  )
+
   return <div className="m-auto">
     <div className="carro-bg">
       <Header />
@@ -56,23 +71,8 @@ function Carro2() {
     </div>
 
     <TwoColumnLayoutTwo
-      child1={
-        ClientBlocks.carro.map(carro =>
-          <AngledImage
-            image={carro.image}
-            layout="left"
-          />
-        )
-    }
-      child2={
-          ClientBlocks.carro.map(carro =>
-            <StandardTextBlock
-              sub={carro.sub}
-              title={carro.title}
-              text={carro.text}
-            />
-          )
-      }
+      child1={carroImages}
+      child2={carroText}
     >
     </TwoColumnLayoutTwo>
 


### PR DESCRIPTION
@baudoinalkali - here's a quick improvement on the way you're using props to render the layout in the higher order component. 

Using `{ . . . }` for your props is great because it allows you to execute JavaScript in your prop values, but you want to be a little careful about overdoing it *inline*. 

You had the `map` statements running inline in the JSX portion of this component. I moved them to their own constant values. You could also potentially write these as functions as well, but this works fine here. The biggest takeaway is that if you see multi-line statements and expressions in your props, it's a [code smell](https://en.wikipedia.org/wiki/Code_smell) that you have some missed abstraction that should be represented as an external function. This helps you clean things up a little bit and reason about the code a little easier. 