### PR TITLE
Resolve 22 client name

### DIFF
--- a/components/ClientContainer.tsx
+++ b/components/ClientContainer.tsx
@@ -1,6 +1,6 @@
 const ClientContainer = props => {
     return (
-        <a href={`/clients/${props.name.toLowerCase()}`}>
+        <a href={`/clients/${props.slug}`}>
             <li className="portfolio1 rounded-md shadow-2xl m-auto w-64 ease-in-out bg-white hover:bg-alkaligrey-700 transition duration-500 transform hover:-translate-y-1 hover:scale-110" style={{ backgroundImage: `url("/images/${props.backgroundImg}")`, backgroundRepeat: "no-repeat", backgroundSize: "cover" }}>
                 <h3 className="font-open rounded-md text-3xl text-white pl-2 pt-80 pl-5 pb-4">{props.name}</h3>
             </li>

--- a/components/ClientContainer.tsx
+++ b/components/ClientContainer.tsx
@@ -1,10 +1,10 @@
-const ClientContainers = props => {
+const ClientContainer = props => {
     return (
-        <a href={`/clients/`}>
+        <a href={`/clients/${props.name.toLowerCase()}`}>
             <li className="portfolio1 rounded-md shadow-2xl m-auto w-64 ease-in-out bg-white hover:bg-alkaligrey-700 transition duration-500 transform hover:-translate-y-1 hover:scale-110" style={{ backgroundImage: `url("/images/${props.backgroundImg}")`, backgroundRepeat: "no-repeat", backgroundSize: "cover" }}>
                 <h3 className="font-open rounded-md text-3xl text-white pl-2 pt-80 pl-5 pb-4">{props.name}</h3>
             </li>
         </a>
     )
 }
-export default ClientContainers
+export default ClientContainer

--- a/content/clientPages/clientMainPage.ts
+++ b/content/clientPages/clientMainPage.ts
@@ -1,19 +1,23 @@
 const clientMainPage = [
     {
         name: "Carro",
-        backgroundImg: "carro-cover.jpg"
+        backgroundImg: "carro-cover.jpg",
+        slug: 'carro',
+    },
+    {
+        name: "CarTalk",
+        backgroundImg: "carro-cover.jpg",
+        slug: 'car-talk',
     },
     {
         name: "Carro",
-        backgroundImg: "carro-cover.jpg"
+        backgroundImg: "carro-cover.jpg",
+        slug: 'carro',
     },
     {
         name: "Carro",
-        backgroundImg: "carro-cover.jpg"
-    },
-    {
-        name: "Carro",
-        backgroundImg: "carro-cover.jpg"
+        backgroundImg: "carro-cover.jpg",
+        slug: 'carro'
     }
 ]
 export default clientMainPage;

--- a/pages/clients.tsx
+++ b/pages/clients.tsx
@@ -27,6 +27,7 @@ function Clients() {
         <ClientContainer
           name={clientMainPage.name}
           backgroundImg={clientMainPage.backgroundImg}
+          slug={clientMainPage.slug}
         />
       )}
     </ClientsSummary>

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,6 +496,11 @@ classnames@2.2.6, classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.2.6:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1615,6 +1620,11 @@ react-dom@17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
+react-intersection-observer@^8.26.2:
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.31.0.tgz#0ed21aaf93c4c0475b22b0ccaba6169076d01605"
+  integrity sha512-XraIC/tkrD9JtrmVA7ypEN1QIpKc52mXBH1u/bz/aicRLo8QQEJQAMUTb8mz4B6dqpPwyzgjrr7Ljv/2ACDtqw==
+
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -1635,6 +1645,15 @@ react-slick@^0.28.1:
     json2mq "^0.2.0"
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
+
+react-vertical-timeline-component@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/react-vertical-timeline-component/-/react-vertical-timeline-component-3.3.3.tgz#0c87e92be0af11ea895743f267be0e07e941e8e1"
+  integrity sha512-zvztiWKFYYPqq0vDrWoBcLJC6ok5A4nvdgxHq94JKVyjwUypojGHZQxDSjDzmLkgLRrA2kVjNzfNnv6eQ/O80A==
+  dependencies:
+    classnames "^2.2.6"
+    prop-types "^15.7.2"
+    react-intersection-observer "^8.26.2"
 
 react@17.0.1:
   version "17.0.1"


### PR DESCRIPTION
@baudoinalkali, honestly, my opinion is the best move here is to hardcode the slug itself. 

If you want to get more clever with it, you could use a package like [slugify](https://www.npmjs.com/package/slugify) to convert whitespace to hyphens, but you'd still have to handle the [CamelCase](https://en.wikipedia.org/wiki/Camel_case) names like `CarTalk`. 

This also works well because sometimes you may find your page slugs won't line up 1-to-1 with the company names, so setting it manually gives you a really good way to control it fine-grained. 

This is one of those instances where the value of programmatically generating a value may be juice that isn't really worth the squeeze. My guess is once you set these slugs once, they will change very rarely if often. It's probably worth the time to just write the slug yourself. 