### PR TITLE
fix Nextjs Image component unintended whitespace

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,7 +4,7 @@ function Footer() {
     return (
         <div className="bg-black">
             <div className="flex py-10 flex flex-col space-x-0 md:space-x-14 md:flex-row justify-between max-w-7xl justify-center m-auto mx-14 xl:mx-auto">
-                <div className="w-full md:w-2/5 m-auto">
+                <div className="w-full md:w-2/5 m-auto" style={{fontSize: '0'}}>
                     <Image
                         src="/images/alkalismall.png"
                         width={64}

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -25,7 +25,7 @@ const Integrations = props => {
             <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-y-10 max-w-7xl m-auto">
                 {
                     integration.map((integration) =>
-                        <div className="relative m-auto">
+                        <div className="relative m-auto" style={{fontSize: '0'}}>
                             <Image
                                 height={144}
                                 width={144}

--- a/components/Navigation/DesktopNavigation.tsx
+++ b/components/Navigation/DesktopNavigation.tsx
@@ -21,7 +21,7 @@ const DesktopNavigation = props => {
         <div className={props.style}>
             <div className="flex justify-between max-w-7xl justify-center m-auto py-7">
                 <div className="flex items-center">
-                    <a>
+                    <a style={{fontSize: '0'}}>
                         <Image
                             src="/images/alkali-logo-blue.png"
                             width={160}

--- a/components/Navigation/MobileNavigation.tsx
+++ b/components/Navigation/MobileNavigation.tsx
@@ -52,7 +52,7 @@ export const NavigationRound2 = () => {
         <>
             <div className="bg-alkaligrey-200">
                 <nav className='flex items-center flex-wrap p-3 max-w-7xl m-auto'>
-                    <a className='inline-flex items-center p-2 mr-4 '>
+                    <a className='inline-flex items-center p-2 mr-4 ' style={{fontSize: '0'}}>
                         <Image 
                         src="/images/alkali-logo-blue.png"
                         width={160}

--- a/components/ResponsiveScreens.tsx
+++ b/components/ResponsiveScreens.tsx
@@ -10,7 +10,7 @@ const ResponsiveScreens = props => {
                     <div className="p-4 flex justify-between items-center max-w-7xl m-auto">
                         <div className="screenshot-container mx-3">
                             <a href={props.desktopLeftLink}>
-                                <div className="-mb-10 rounded-md screenshot-d shadow-2xl duration-500 transform -rotate-45 -translate-x-24 hover:-translate-y-1 hover:scale-110">
+                                <div className="-mb-10 rounded-md screenshot-d shadow-2xl duration-500 transform -rotate-45 -translate-x-24 hover:-translate-y-1 hover:scale-110" style={{fontSize: '0'}}>
                                     <Image
                                         className="rounded-md"
                                         src={props.desktopLeft}
@@ -23,7 +23,7 @@ const ResponsiveScreens = props => {
                         </div>
                         <div className="screenshot-container mx-3 mb-4">
                             <a href={props.desktopRightLink}>
-                                <div className="rounded-md screenshot-d-alt shadow-2xl duration-500 transform rotate-45 translate-x-24 translate-y-3 hover:-translate-y-1 hover:scale-110">
+                                <div className="rounded-md screenshot-d-alt shadow-2xl duration-500 transform rotate-45 translate-x-24 translate-y-3 hover:-translate-y-1 hover:scale-110" style={{fontSize: '0'}}>
                                     <Image
                                         className="rounded-md"
                                         src={props.desktopRight}
@@ -38,7 +38,7 @@ const ResponsiveScreens = props => {
                     <div className="p-4 flex justify-between items-center max-w-7xl m-auto">
                         <div className="screenshot-container w-2/3 mx-3">
                             <a href={props.tabletLink}>
-                                <div className="screenshot-t w-96 shadow-2xl duration-500 transform -rotate-45 -translate-x-21 hover:-translate-y-1 hover:scale-110">
+                                <div className="screenshot-t w-96 shadow-2xl duration-500 transform -rotate-45 -translate-x-21 hover:-translate-y-1 hover:scale-110" style={{fontSize: '0'}}>
                                     <Image
                                         className=""
                                         src={props.tablet}
@@ -51,7 +51,7 @@ const ResponsiveScreens = props => {
                         </div>
                         <div className="text-center screenshot-container w-1/3 mx-3">
                             <a href={props.phoneLink}>
-                                <div className="rounded-md screenshot-p w-52 shadow-2xl duration-500 transform -rotate-45 -translate-x-21 hover:-translate-y-1 hover:scale-110">
+                                <div className="rounded-md screenshot-p w-52 shadow-2xl duration-500 transform -rotate-45 -translate-x-21 hover:-translate-y-1 hover:scale-110" style={{fontSize: '0'}}>
                                     <Image
                                         className="rounded-md"
                                         src={props.phone}

--- a/components/Services/ServiceHero.tsx
+++ b/components/Services/ServiceHero.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 const ServiceHero = props => {
     return (
         <div>
-            <div className="relative">
+            <div className="relative" style={{fontSize: '0'}}>
                 <Image
                     layout="fill"
                     className="object-center object-cover pointer-events-none"

--- a/components/StandardImage.tsx
+++ b/components/StandardImage.tsx
@@ -26,7 +26,7 @@ const StandardImage = (props) => {
     
     return (
         <div>
-            <div className={imageContainerAngle()}>
+            <div className={imageContainerAngle()} style={{fontSize: '0'}}>
             <Image 
             className={imageAngle()}
             src={props.image}

--- a/components/TestimonialSlide.tsx
+++ b/components/TestimonialSlide.tsx
@@ -5,7 +5,7 @@ const TestimonialSlide = (props) => {
         <div className={props.style}>
             <div className="relative">
                 <div className="relative lg:flex overflow-hidden rounded-md">
-                    <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center">
+                    <div className="h-56 lg:h-auto lg:w-5/12 relative flex items-center justify-center" style={{fontSize: '0'}}>
                         <Image 
                             className="absolute object-cover"
                             src={props.background}

--- a/pages/services/web-development/wordpress-website-development.tsx
+++ b/pages/services/web-development/wordpress-website-development.tsx
@@ -123,7 +123,7 @@ function WordPressWebsiteDevelopment() {
                     </div>
                     <div className="z-0 pointer-events-none">
                         <div className="angled-mockup rounded-md shadow-2xl mx-14">
-                            <div className="browser-mockup z-0">
+                            <div className="browser-mockup z-0" style={{fontSize: '0'}}>
                                 <Image
                                 src="/images/wordpress-stats.png"
                                 alt=""


### PR DESCRIPTION
Hey @baudoinalkali - looks like [other people are experiencing this issue as well](https://github.com/vercel/next.js/issues/21914). 

I used [this tip about setting `font-size: 0` on parent elements](https://github.com/vercel/next.js/issues/21914#issuecomment-777886877) to fix it for now. I pre-emptively added it to each of the parents of every instance of `<Image />` component I saw. 

Closes #56 