### PR TITLE
add the content directory to the purge configuration

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}', './content/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
     fontFamily: {


### PR DESCRIPTION
@baudoinalkali - you had [the standard Tailwind PurgeCSS configuration](https://tailwindcss.com/docs/guides/nextjs#configure-tailwind-to-remove-unused-styles-in-production), which assumes that _all of the Tailwind utilities in use_ exist in the `components/` or `pages/` directory. 

[This is how PurgeCSS works in Tailwind](https://tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html). Since you're storing `bg-alkali-600` in the `content/` folder, PurgeCSS needs to search the `content/` directory for any instances of utility classes you intend to use, in order to send them along with production. 

Closes #58 