### PR TITLE
Resolve 67 alternative pseudo element class

### DIFF
--- a/components/Services/OurProcess.tsx
+++ b/components/Services/OurProcess.tsx
@@ -7,10 +7,11 @@ const OurProcess = props => {
     }
 
     const eventDotClass = () => {
+        const pseudoElementClass = props.isLastItem ? 'skipVerticalLine' : ''
         if (props.type % 2 === 0) {
-            return `event-dotR ${props.isLastItem ? 'skipVerticalLine' : ''} ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+            return `event-dotR ${pseudoElementClass} ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
         } else {
-            return `event-dotL ${props.isLastItem ? 'skipVerticalLine' : ''} ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+            return `event-dotL ${pseudoElementClass} ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
         }
     }
 

--- a/components/Services/OurProcess.tsx
+++ b/components/Services/OurProcess.tsx
@@ -8,11 +8,10 @@ const OurProcess = props => {
 
     const eventDotClass = () => {
         const pseudoElementClass = props.isLastItem ? 'skipVerticalLine' : ''
-        if (props.type % 2 === 0) {
-            return `event-dotR ${pseudoElementClass} ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
-        } else {
-            return `event-dotL ${pseudoElementClass} ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
-        }
+        const directionalClass = props.type % 2 === 0 ? 'event-dotR md:ml-7' : 'event-dotL md:mr-7'
+        
+        return `${directionalClass} ${pseudoElementClass} ml-0 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+
     }
 
     const eventTitleContainerClass = () => {

--- a/components/Services/OurProcess.tsx
+++ b/components/Services/OurProcess.tsx
@@ -7,8 +7,8 @@ const OurProcess = props => {
     }
 
     const eventDotClass = () => {
-        const pseudoElementClass = props.isLastItem ? 'skipVerticalLine' : ''
         const directionalClass = props.type % 2 === 0 ? 'event-dotR md:ml-7' : 'event-dotL md:mr-7'
+        const pseudoElementClass = props.isLastItem ? 'skipVerticalLine' : ''
         
         return `${directionalClass} ${pseudoElementClass} ml-0 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
 

--- a/components/Services/OurProcess.tsx
+++ b/components/Services/OurProcess.tsx
@@ -7,7 +7,13 @@ const OurProcess = props => {
     }
 
     const eventDotClass = () => {
-        return `${props.type % 2 === 0 ? 'event-dotR ml-0 md:ml-7' : 'event-dotL ml-0 md:mr-7'}  bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+        if (props.isLastItem) {
+            return `${props.type % 2 === 0 ? 'event-dotR ml-0 md:ml-7' : 'event-dotL ml-0 md:mr-7'} skipVerticalLine bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+        } else if (props.type % 2 === 0) {
+            return `event-dotR ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+        } else {
+            return `event-dotL ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+        }
     }
 
     const eventTitleContainerClass = () => {
@@ -15,7 +21,7 @@ const OurProcess = props => {
     }
 
     const eventTextContainerClass = () => {
-        return `${props.type %2 === 0 ? `rounded-b-md md:rounded-b-none md:rounded-l-md` : `rounded-b-md md:rounded-b-none md:rounded-r-md`} bg-white p-4 py-8 shadow-none md:shadow-2xl w-full md:w-8/12`
+        return `${props.type % 2 === 0 ? `rounded-b-md md:rounded-b-none md:rounded-l-md` : `rounded-b-md md:rounded-b-none md:rounded-r-md`} bg-white p-4 py-8 shadow-none md:shadow-2xl w-full md:w-8/12`
     }
     const icons = {
         'faSearch': faSearch,
@@ -35,9 +41,9 @@ const OurProcess = props => {
                     <div className="relative self-center text-center px-4 pb-7 md:pb-0">{props.title}</div>
                 </div>
                 <div className={eventTextContainerClass()}>
-                    <div 
-                    className="text-center sm:text-left ml-none sm:ml-7 lg:ml-14"
-                    dangerouslySetInnerHTML={{__html: props.step}}
+                    <div
+                        className="text-center sm:text-left ml-none sm:ml-7 lg:ml-14"
+                        dangerouslySetInnerHTML={{ __html: props.step }}
                     >
                     </div>
                 </div>

--- a/components/Services/OurProcess.tsx
+++ b/components/Services/OurProcess.tsx
@@ -7,12 +7,10 @@ const OurProcess = props => {
     }
 
     const eventDotClass = () => {
-        if (props.isLastItem) {
-            return `${props.type % 2 === 0 ? 'event-dotR ml-0 md:ml-7' : 'event-dotL ml-0 md:mr-7'} skipVerticalLine bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
-        } else if (props.type % 2 === 0) {
-            return `event-dotR ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+        if (props.type % 2 === 0) {
+            return `event-dotR ${props.isLastItem ? 'skipVerticalLine' : ''} ml-0 md:ml-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
         } else {
-            return `event-dotL ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
+            return `event-dotL ${props.isLastItem ? 'skipVerticalLine' : ''} ml-0 md:mr-7 bg-alkali-500 text-center rounded-none md:rounded-full w-auto h-auto md:w-20 md:h-20 self-stretch md:self-center p-6 shadow-none md:shadow-2xl rounded-t-md md:rounded-none`
         }
     }
 

--- a/pages/services/digital-marketing/local-search-engine-optimization.tsx
+++ b/pages/services/digital-marketing/local-search-engine-optimization.tsx
@@ -296,6 +296,7 @@ function LocalSearchEngineOptimization() {
                         step={seo.step}
                         icon={seo.icon}
                         type={index}
+                        isLastItem={index === seoProcess.seo.length - 1}
                     />
                 )}
                 <div className="max-w-5xl bg-white py-20 m-auto rounded-md shadow-2xl text-alkali-500 text-center text-white text-3xl z-20 relative">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -238,6 +238,11 @@ a {
     transform: translateY(-50%);
 }
 
+.event-dotR.skipVerticalLine::before,
+.event-dotL.skipVerticalLine::before {
+	display: none;
+}
+
 .IntegrationIcon:hover > .IconSpan {
 	opacity: 1;
 }


### PR DESCRIPTION
Closes #67 

@baudoinalkali - here's how I would do this. I wrote a class to override your `before` element based on whether or not the `OurProcess` component is told it's the last one (via a new prop). Then, in the dot class, I reconfigured the logic a little bit. There are now two constants that represent your conditional classnames:

1. `directionalClass` checks if the `type` prop is even or odd, and applies the right/left classes (`event-dotR` and `md:mr-7`, etc.). 
1. `pseudoElementClass` checks a new prop, `isLastItem`. If it's the last item, then you apply a `skipVerticalLine` CSS class to it, which just sets the `before` pseudoelement to `display: none`. 

You could keep these inline or use `if/else` statements (if you look through the commit history, you'll see I played around with this a little). I like this approach because it clearly communicates to readers: "Hey, there are two different sets of conditional classes, here's how we determine them", and then the classes that never change get to stay the same. 

In `pages/services/digital-marketing/local-search-engine-optimization.tsx`, I set the `isLastItem` prop by checking if the `index` is equal to the `length - 1` of the array you're mapping over (remember, arrays start indexing at `0`, so if you have 8 items in an array, the last one will be at position `7`). 

This feels pretty clean and extensible, in my opinion. You could rename `isLastItem` to something like `skipVerticalBar` as well, and then have the option to skip the bar based on any arbitrary reason. 
